### PR TITLE
Fixes for STRICT STANDARD errors in PHP 5.6

### DIFF
--- a/classes/NPRAPI.php
+++ b/classes/NPRAPI.php
@@ -22,6 +22,21 @@ class NPRAPI {
   const NPRML_VERSION = '0.92.2';
 
   /**
+   * @var string[]
+   */
+  var $notices;
+
+  /**
+   * @var object
+   */
+  var $message;
+
+  /**
+   * @var array[]
+   */
+  var $stories;
+
+  /**
    * Initializes an NPRML object.
    */
   function __construct() {
@@ -37,7 +52,14 @@ class NPRAPI {
     $this->response->code = NULL;
   }
 
-  function request() {
+  /**
+   * Makes HTTP request to NPR API.
+   *
+   * @param array $params Key/value pairs to be sent (within the request's query string).
+   * @param string $path The path part of the request URL (i.e., http://example.com/PATH).
+   * @param string $base The base URL of the request (i.e., HTTP://EXAMPLE.COM/path) with no trailing slash.
+   */
+  function request( $params = array(), $path = 'query', $base = self::NPRAPI_PULL_URL ) {
 
   }
 
@@ -45,7 +67,15 @@ class NPRAPI {
 
   }
 
-  function send_request() {
+  /**
+   * This function will send the push request to the NPR API to add/update a story.
+   *
+   * @see NPRAPI::send_request()
+   *
+   * @param string $nprml
+   * @param int $post_ID
+   */
+  function send_request( $nprml, $post_ID ) {
 
   }
 
@@ -61,7 +91,14 @@ class NPRAPI {
 
   }
 
-  function create_NPRML() {
+  /**
+   * Create NPRML from wordpress post.
+   *
+   * @param WP_Post $post A WordPress post object.
+   *
+   * @return bool|string An NPRML string.
+   */
+  function create_NPRML( $post ) {
 
   }
 
@@ -125,10 +162,10 @@ class NPRAPI {
                 $my_array[] = $parsed->{$key};
                 $parsed->{$key} = $my_array;
               }
-              // then add the new child. 
+              // then add the new child.
               $parsed->{$key}[] = $this->parse_simplexml_element($current);
             }
-            else {  
+            else {
               //The key wasn't parsed already, so just add the current element.
               $parsed->{$key} = $this->parse_simplexml_element($current);
             }
@@ -148,23 +185,21 @@ class NPRAPI {
       //there are no params and 'sort=' is not in the URL
       if (empty($this->request->params) && !stristr($this->request->url, 'sort=')){
       	$this->stories = array_reverse($this->stories);
-      } 
+      }
       //there are params, and sort is not one of them
       if (!empty($this->request->params) && !array_key_exists('sort', $this->request->params)){
       	$this->stories = array_reverse($this->stories);
       }
-      
+
     }
   }
 
   /**
    * Converts SimpleXML element into NPRMLElement.
    *
-   * @param object $element
-   *   A SimpleXML element.
+   * @param SimpleXMLElement $element
    *
-   * @return object
-   *   An NPRML element.
+   * @return NPRMLElement
    */
   function parse_simplexml_element($element) {
     $NPRMLElement = new NPRMLElement();
@@ -189,10 +224,10 @@ class NPRAPI {
               $my_array[] = $NPRMLElement->$i;
               $NPRMLElement->$i = $my_array;
             }
-            // then add the new child. 
+            // then add the new child.
             $NPRMLElement->{$i}[] = $this->parse_simplexml_element($child);
           }
-          else {  
+          else {
             $NPRMLElement->$i = $this->parse_simplexml_element($child);
           }
         }
@@ -227,8 +262,7 @@ class NPRAPI {
   /**
    * Generates basic report of NPRML object.
    *
-   * @return array
-   *   Various messages (strings) .
+   * @return string[] Various messages.
    */
   function report() {
     $msg = array();
@@ -262,11 +296,9 @@ class NPRAPI {
   /**
    * Takes attributes of a SimpleXML element and adds them to an object (as properties).
    *
-   * @param object $element
-   *   A SimpleXML element.
+   * @param SimpleXMLElement $element
    *
-   * @param object $object
-   *   Any PHP object.
+   * @param object $object Any PHP object.
    */
   function add_simplexml_attributes($element, $object) {
     if (count($element->attributes())) {
@@ -288,7 +320,16 @@ class NPRMLEntity {
  * Basic OOP container for NPRML element.
  */
 class NPRMLElement {
+
+  /**
+   * @var mixed
+   */
+  var $value;
+
+  /**
+   * @return string
+   */
   function __toString() {
-    return $this->value;
+    return (string) $this->value;
   }
 }

--- a/get_stories.php
+++ b/get_stories.php
@@ -16,11 +16,11 @@ class DS_NPR_API {
 	public static function ds_npr_story_cron_pull() {
 		// here we should get the list of IDs/full urls that need to be checked hourly
 		//because this is run on cron, and may be fired off by an non-admin, we need to load a bunch of stuff
-		require_once (WP_PLUGIN_DIR . '/../../wp-admin/includes/file.php');
-		require_once (WP_PLUGIN_DIR . '/../../wp-admin/includes/media.php');
-		require_once (WP_PLUGIN_DIR . '/../../wp-admin/includes/admin.php');
-		require_once (WP_PLUGIN_DIR . '/../../wp-load.php');
-		require_once (WP_PLUGIN_DIR . '/../../wp-includes/class-wp-error.php');
+        require_once( ABSPATH . 'wp-admin/includes/file.php');
+        require_once( ABSPATH . 'wp-admin/includes/media.php');
+        require_once( ABSPATH . 'wp-admin/includes/admin.php');
+        require_once( ABSPATH . 'wp-load.php');
+        require_once( ABSPATH . WPINC . '/class-wp-error.php');
 
 		//this was debug code it may be good keep it around for a bit
 		//$now = gmDate("D, d M Y G:i:s O ");
@@ -28,7 +28,7 @@ class DS_NPR_API {
 		//here we go.
 		$num =  get_option( 'ds_npr_num' );
 		for ($i=0; $i<$num; $i++ ) {
-			$api = new NPRAPIWordpress(); 
+			$api = new NPRAPIWordpress();
 			$q = 'ds_npr_query_' . $i;
 			$query_string = get_option( $q );
 			if ( ! empty( $query_string ) ) {
@@ -81,10 +81,10 @@ class DS_NPR_API {
         } else if ( isset( $_GET['story_id']) && isset( $_GET['create_draft'] ) ) {
             $story_id = $_GET['story_id'];
         }
-        
+
         if ( isset( $story_id ) ) {
             // XXX: check that the API key is actually set
-            $api = new NPRAPIWordpress(); 
+            $api = new NPRAPIWordpress();
             //check to see if we got an ID or a URL
             if ( is_numeric( $story_id ) ) {
                 if (strlen($story_id) >= 8) {
@@ -102,7 +102,7 @@ class DS_NPR_API {
             $params = array( 'id' => $story_id, 'apiKey' => get_option( 'ds_npr_api_key' ) );
             $api->request( $params, 'query', get_option( 'ds_npr_api_pull_url' ) );
             $api->parse();
-            
+
             if ( empty( $api->message ) || $api->message->level != 'warning') {
                 $post_id = $api->update_posts_from_stories($publish);
                 if ( ! empty( $post_id ) ) {
@@ -128,11 +128,11 @@ class DS_NPR_API {
         add_action( 'admin_menu', array( &$this, 'admin_menu' ) );
         add_action( 'load-posts_page_get-npr-stories', array( 'DS_NPR_API', 'load_page_hook' ) );
     }
-	
+
     function admin_menu() {
         add_posts_page( 'Get NPR DS Stories', 'Get DS NPR Stories', 'edit_posts', 'get-npr-stories',   'ds_npr_get_stories' );
     }
-    
+
 }
 
 new DS_NPR_API;

--- a/push_story.php
+++ b/push_story.php
@@ -5,8 +5,8 @@ require_once ( 'classes/NPRAPIWordpress.php' );
 /**
  *
  * push the contents and fields for a post to the NPR API
- * @param unknown_type $post_ID
- * @param unknown_type $post
+ * @param int $post_ID
+ * @param WP_Post $post
  */
 function npr_push ( $post_ID, $post ) {
 	$push_post_type = get_option( 'ds_npr_push_post_type' );
@@ -57,7 +57,7 @@ function npr_push ( $post_ID, $post ) {
 /**
  *
  * Inform the NPR API that a post needs to be deleted.
- * @param unknown_type $post_ID
+ * @param int $post_ID
  */
 function npr_delete ( $post_ID ) {
 	$push_post_type = get_option( 'ds_npr_push_post_type' );
@@ -121,7 +121,8 @@ function ds_npr_api_push_mapping_callback() { }
  * Query the database for any meta fields for a post type, then store that in a WP transient/cache for a day.
  * I don't see the need for this cache to be any shorter, there's not a lot of adding of meta keys happening.
  * To clear this cache, after adding meta keys, you need to run delete_transient('ds_npr_' .  $post_type.'_meta_keys')
- * @param  $post_type
+ * @param string $post_type
+ * @return string[]
  */
 function ds_npr_push_meta_keys( $post_type = 'post' ) {
     global $wpdb;
@@ -148,7 +149,8 @@ function ds_npr_push_meta_keys( $post_type = 'post' ) {
  *
  * get the meta keys for a post type, they could be stored in a cache.
  *
- * @param  $post_type default is 'post'
+ * @param string $post_type default is 'post'
+ * @return string[]
  */
 function ds_npr_get_post_meta_keys( $post_type = 'post' ) {
     //$cache = get_transient('ds_npr_' .  $post_type .'_meta_keys');
@@ -286,8 +288,8 @@ function ds_npr_api_mapping_distribute_media_polarity_callback() {
 /**
  *
  * create the select widget of all meta fields
- * @param  $field_name
- * @param  $keys
+ * @param string $field_name
+ * @param string[] $keys
  */
 function ds_npr_show_keys_select( $field_name, $keys ) {
 
@@ -308,6 +310,9 @@ function ds_npr_show_keys_select( $field_name, $keys ) {
 
 }
 
+/**
+ * @return string
+ */
 function ds_npr_get_push_post_type() {
 	$push_post_type = get_option( 'ds_npr_push_post_type' );
 	if ( empty($push_post_type) ) {
@@ -316,6 +321,9 @@ function ds_npr_get_push_post_type() {
 	return $push_post_type;
 }
 
+/**
+ * @return null|string[]
+ */
 function ds_npr_get_permission_groups(){
     $perm_groups = '';
 	//query the API for the lists for this org.
@@ -415,6 +423,12 @@ function send_to_nprone() {
 }
 
 add_action( 'save_post', 'save_send_to_nprone');
+
+/**
+ * @param int $post_ID
+ *
+ * @return bool|void
+ */
 function save_send_to_nprone( $post_ID ) {
     global $post;
     if ( get_post_type($post) != get_option('ds_npr_push_post_type') ) return false;


### PR DESCRIPTION
We are working on a project for WABE.org and are using PHP 5.6 and the plugin is throwing STRICT STANDARDS errors for a site that will launch Monday Sept 28th 2015.  So I am providing a fix for those issues as well as fixing several other small issues I found, see below.

The fixes are not of the nature that are likely to break anything for existing sites; I avoiding making any backward incompatible changes.

Here is what this pull request includes:

- Fixes for STRICT STANDARD error through in PHP 5.6 when the signatures of methods in both parent and child classes do not match.
- Added class instance properties where they are obviously used but not declared.
- Added lots of PHPDoc to allow PhpStorm to error check the code.
- Used the correct constants for WordPress for `require()` statements, ones that do not assume the location of the plugin.
- Replaced calls to deprecated `split()` with calls to `explode()`
- Removed potentially problematic trailing `?>` from `nprml.php`
- Cleaned up whitespace (ONLY because PhpStorm would not allow me to leave the whitespace as is.)