### PR TITLE
Update release.sh preparatory to deploying to wordpress.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-release
+release/

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 RELEASE_DIR=release;
 SVN_PATH=$RELEASE_DIR/svn;
-SVN_REPO="https://plugins.svn.wordpress.org/plugin-slug-goes-here/";
+SVN_REPO="https://plugins.svn.wordpress.org/npr-story-api/";
 BLACKLIST=(
 .\*
 release.sh


### PR DESCRIPTION
These small changes now allow `release.sh` to be used to push the plugin to wordpress.org.

Released plugin: https://wordpress.org/plugins/npr-story-api/

Instructions for `release.sh`: https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md