### PR TITLE
Remove a collection of unnecessary error_logs, fix "cannot modify header information"

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -463,7 +463,7 @@ class NPRAPIWordpress extends NPRAPI {
             }
         } else {
             $error_text = 'OrgID was not set when tried to push post_ID ' . $post_ID . ' to the NPR Story API.';
-            error_log $error_text ); // debug use
+            error_log ( $error_text ); // debug use
         }
 
 		// Add errors to the post that you just tried to push

--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -82,7 +82,7 @@ class NPRAPIWordpress extends NPRAPI {
                 $error_text = '<br> HTTP Error response =  '. $response->errors['http_request_failed'][0];
             }
             nprstory_show_message( 'Error pulling story for url='.$url . $error_text, TRUE );
-            error_log( 'Error retrieving story for url='.$url );
+            nprstory_error_log( 'Error retrieving story for url='.$url ); 
         }
     }
 
@@ -273,7 +273,7 @@ class NPRAPIWordpress extends NPRAPI {
                             if ( empty( $image_url ) ) {
                                 $image_url = $image->src;
                             }
-                            error_log('Got image from: ' . $image_url);
+                            nprstory_error_log('Got image from: ' . $image_url);
                             // Download file to temp location
                             $tmp = download_url( $image_url );
 
@@ -431,7 +431,7 @@ class NPRAPIWordpress extends NPRAPI {
                 'apiKey' => get_option( 'ds_npr_api_key' )
             ), get_option( 'ds_npr_api_push_url' ) . '/story' );
 
-            error_log('Sending nprml = ' . $nprml);
+            nprstory_error_log('Sending nprml = ' . $nprml);
 
             $result = wp_remote_post( $url, array( 'body' => $nprml ) );
             if ( ! is_wp_error( $result ) ) {
@@ -441,9 +441,8 @@ class NPRAPIWordpress extends NPRAPI {
                         $response_xml = simplexml_load_string( $body );
                         $npr_story_id = (string) $response_xml->list->story['id'];
                         update_post_meta( $post_ID, NPR_STORY_ID_META_KEY, $npr_story_id );
-                    }
-                    else {
-                        error_log( 'NPR API Push ERROR: ' . print_r( $result, true ) );
+                    } else {
+                        error_log( 'Error returned from NPR Story API with status code 200 OK but failed wp_remote_retrieve_body: ' . print_r( $result, true ) ); // debug use
                     }
                 } else {
                     $error_text = '';
@@ -456,15 +455,15 @@ class NPRAPIWordpress extends NPRAPI {
                         $response_xml = simplexml_load_string( $body );
                         $error_text .= '  API Error Message = ' . $response_xml->message->text;
                     }
-                    error_log('Error returned from API ' . $error_text);
+                    error_log('Error returned from NPR Story API with status code other than 200 OK: ' . $error_text); // debug use
                 }
             } else {
-                $error_text = 'WP Error returned from sending story with post_id = '. $post_ID .' for url='.$url . ' to API ='. $result->get_error_message();
-                error_log($error_text);
+                $error_text = 'WP_Error returned when sending story with post_ID ' . $post_ID . ' for url ' . $url . ' to NPR Story API:'. $result->get_error_message();
+                error_log($error_text); // debug use
             }
         } else {
-            $error_text = 'Tried to push, but OrgID was not set for post_id ='. $post_ID;
-            error_log($error_text);
+            $error_text = 'OrgID was not set when tried to push post_ID ' . $post_ID . ' to the NPR Story API.';
+            error_log($error_text); // debug use
         }
 
 		// Add errors to the post that you just tried to push

--- a/classes/nprml.php
+++ b/classes/nprml.php
@@ -453,5 +453,3 @@ function nprstory_nai_get_excerpt( $post, $word_count = 30 ) {
     }
     return $text;
 }
-
-?>

--- a/classes/nprml.php
+++ b/classes/nprml.php
@@ -118,10 +118,10 @@ function nprstory_post_to_nprml_story( $post ) {
                 );
             }		
         } else {
-            error_log( 'we do not have co authors' );
+            nprstory_error_log( 'we do not have co authors' );
     	}
     } else {
-   		error_log('can not find get_coauthors');
+   		nprstory_error_log('can not find get_coauthors');
    	}    
     if ( ! $byline ) {
         $story[] = array(
@@ -382,12 +382,15 @@ function nprstory_nprml_array_to_xml( $tag, $attrs, $data ) {
 /**
  * convert a loosely-defined item to XML
  *
+ * @todo figure out way for this to safely fail
+ *
  * @param Array $item Must have a key 'tag'
  * @param DOMDocument $xml
  */
 function nprstory_nprml_item_to_xml( $item, $xml ) {
     if ( ! array_key_exists( 'tag', $item ) ) {
-        error_log( "no tag for: " . print_r( $item, true ) );
+        error_log( "Unable to convert NPRML item to XML: no tag for: " . print_r( $item, true ) ); // debug use
+		// this should actually be a serious error
     }
     $elem = $xml->createElement( $item[ 'tag' ] );
     if ( array_key_exists( 'children', $item ) ) {

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -178,8 +178,8 @@ add_action('add_meta_boxes', 'nprstory_add_meta_boxes');
  * This should only be used for error_log in development environments
  * If the thing being logged is a fatal error, use error_log so it will always be logged
  */
-function nprstory_error_log($thing) {
+function nprstory_error_log( $thing ) {
 	if ( WP_DEBUG ) {
-		error_log($thing); //debug use
+		error_log( $thing ); //debug use
 	}
 }

--- a/ds-npr-api.php
+++ b/ds-npr-api.php
@@ -83,7 +83,7 @@ function nprstory_activation() {
 function nprstory_activate() {
 	update_option( 'dp_npr_query_multi_cron_interval', 60 );
 	if ( ! wp_next_scheduled( 'npr_ds_hourly_cron' ) ) {
-		error_log( 'turning on cron event for NPR Story API plugin' );
+		nprstory_error_log( 'turning on cron event for NPR Story API plugin' );
 		wp_schedule_event( time(), 'hourly', 'npr_ds_hourly_cron' );
 	}
 
@@ -171,3 +171,15 @@ function nprstory_add_meta_boxes() {
 	}
 }
 add_action('add_meta_boxes', 'nprstory_add_meta_boxes');
+
+/**
+ * Function to only enable error_logging if WP_DEBUG is true
+ *
+ * This should only be used for error_log in development environments
+ * If the thing being logged is a fatal error, use error_log so it will always be logged
+ */
+function nprstory_error_log($thing) {
+	if ( WP_DEBUG ) {
+		error_log($thing); //debug use
+	}
+}

--- a/get_stories.php
+++ b/get_stories.php
@@ -22,7 +22,7 @@ class DS_NPR_API {
 		// This is debug code. It may be save future devs some time; please keep it around.
 		/*
 		$now = gmDate("D, d M Y G:i:s O ");
-		error_log("right now the time is -- ".$now);
+		error_log("right now the time is -- ".$now); // debug use
 		*/
 
 		// here we go.
@@ -32,21 +32,20 @@ class DS_NPR_API {
 			$q = 'ds_npr_query_' . $i;
 			$query_string = get_option( $q );
 			if ( ! empty( $query_string ) ) {
-				error_log('Cron '. $i . ' querying NPR API for ' . $query_string);
+				nprstory_error_log('Cron '. $i . ' querying NPR API for ' . $query_string);
 				//if the query string contains the pull url and 'query', just make request from the API
 				if ( stristr( $query_string, get_option( 'ds_npr_api_pull_url' ) ) && stristr( $query_string,'query' ) ) {
 					$api->query_by_url( $query_string );
 				} else {
 				    //if the string doesn't contain the base url, try to query using an ID
 					if ( stristr( $query_string, 'http:' ) ) {
-						error_log('Not going to run query because the query string contains http and is not pointing to the pullURL');
+						error_log('Not going to run query because the query string contains http and is not pointing to the pullURL: ' . $query_string ); // debug use
 					} else {
 						$params = array ('id' => $query_string, 'apiKey' => get_option( 'ds_npr_api_key' ));
                         $api->request( $params, 'query', get_option( 'ds_npr_api_pull_url' ) );
 					}
 				}
 				$api->parse();
-	            //var_dump($api);
                 try {
                     if ( empty( $api->message ) || $api->message->level != 'warning' ) {
                         //check the publish flag and send that along.
@@ -58,12 +57,12 @@ class DS_NPR_API {
                         $story = $api->update_posts_from_stories($pub_flag);
                     } else {
                         if ( empty($story) ) {
-                            error_log('Not going to save story.  Return from query='. $query_string .', we got an error='.$api->message->id. ' error');
+                            error_log('NPR Story API: not going to save story.  Query '. $query_string .' returned an error '.$api->message->id. ' error'); // debug use
                         }
                     }
                 }
                 catch (Exception $e) {
-                    error_log('we have an error going in '. __FUNCTION__. ' like this :'. $e);
+                    error_log('NPR Story API: error in ' .  __FUNCTION__ . ' like this :'. $e); // debug use
                 }
 			}
 		}
@@ -139,7 +138,7 @@ class DS_NPR_API {
                 if ( empty($story) ) {
                     $xml = simplexml_load_string( $api->xml );
                     nprstory_show_message('Error retrieving story for id = ' . $story_id . '<br> API error ='.$api->message->id . '<br> API Message ='. $xml->message->text , TRUE);
-                    error_log('Not going to save the return from query for story_id='. $story_id .', we got an error='.$api->message->id. ' from the API');
+                    error_log('Not going to save the return from query for story_id='. $story_id .', we got an error='.$api->message->id. ' from the NPR Story API'); // debug use
                     return;
 	            }
             }

--- a/get_stories_ui.php
+++ b/get_stories_ui.php
@@ -80,7 +80,7 @@ function nprstory_bulk_action_update_action() {
 				$api->request( $params, 'query', get_option( 'ds_npr_api_pull_url' ) );
 				$api->parse();
 				if ( empty( $api->message ) || $api->message->level != 'warning' ){
-					error_log( 'updating story for API ID='.$api_id );
+					nprstory_error_log( 'updating story for API ID='.$api_id );
 					$story = $api->update_posts_from_stories();
 				}
 			} else {

--- a/push_story.php
+++ b/push_story.php
@@ -63,7 +63,7 @@ function nprstory_api_push ( $post_ID, $post ) {
 		if ( empty( $retrieved ) || $retrieved == 0 ) {
 			$api->send_request( $api->create_NPRML( $post ), $post_ID);
 		} else {
-			//error_log('Not pushing the story because it came from the API');
+			nprstory_error_log('Not pushing the story with post_ID ' . (str)  $post_ID . ' to the NPR Story API because it came from the API');
 		}
 	}
 }
@@ -105,7 +105,7 @@ function nprstory_api_delete ( $post_ID ) {
 		if ( empty( $retrieved ) || $retrieved == 0) {
 			$api->send_request( $api->create_NPRML( $post ), $post_ID);
 		} else {
-			//error_log('Not pushing the story because it came from the API');
+			nprstory_error_log('Pushing delete action to the NPR Story API for the story with post_ID ' . (str)  $post_ID );
 			$api->send_delete( $api_id );
 		}
 	}
@@ -278,7 +278,7 @@ function nprstory_validation_callback_org_id( $value ) {
  * This should not be used in any released code
  */
 function nprstory_validation_callback_debug( $value ) {
-	error_log( var_export( $value, true ) );
+	error_log( var_export( $value, true ) ); // for debug use
 	return $value;
 }
 

--- a/push_story.php
+++ b/push_story.php
@@ -588,14 +588,16 @@ function nprstory_post_updated_messages_success( $messages ) {
 	$id = get_post_meta(get_the_ID(), NPR_STORY_ID_META_KEY, true); // single
 
 	if ( !empty($id) ) {
+
+		// what do we call this thing?
 		$post_type = get_post_type( get_the_ID() );
 		$obj = get_post_type_object( $post_type );
 		$singular = $obj->labels->singular_name;
 
+		// Create the message about the thing being updated
 		$messages['post'][4] = sprintf(
 			__( '%s updated. This post\'s NPR ID is %s. ' ),
 			esc_attr( $singular ),
-			strtolower( $singular ),
 			(string) $id
 		);
 	}

--- a/push_story.php
+++ b/push_story.php
@@ -272,8 +272,10 @@ function nprstory_validation_callback_org_id( $value ) {
 	}
 	return esc_attr( $value );
 }
+
 /**
  * callback for debugging validation callbacks
+ * This should not be used in any released code
  */
 function nprstory_validation_callback_debug( $value ) {
 	error_log( var_export( $value, true ) );

--- a/push_story.php
+++ b/push_story.php
@@ -545,7 +545,7 @@ function nprstory_save_send_to_nprone( $post_ID ) {
     if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return false;
     if ( ! current_user_can( 'edit_page', $post_ID ) ) return false;
     if ( empty( $post_ID ) ) return false;
-    $value = ($_POST['send_to_nprone'] == 1 ) ? 1 : 0;
+    $value = ( isset( $_POST['send_to_nprone'] ) && $_POST['send_to_nprone'] == 1 ) ? 1 : 0;
     update_post_meta( $post_ID, '_send_to_nprone', $value );
 }
 

--- a/push_story.php
+++ b/push_story.php
@@ -63,7 +63,7 @@ function nprstory_api_push ( $post_ID, $post ) {
 		if ( empty( $retrieved ) || $retrieved == 0 ) {
 			$api->send_request( $api->create_NPRML( $post ), $post_ID);
 		} else {
-			nprstory_error_log('Not pushing the story with post_ID ' . (str)  $post_ID . ' to the NPR Story API because it came from the API');
+			nprstory_error_log('Not pushing the story with post_ID ' . $post_ID . ' to the NPR Story API because it came from the API');
 		}
 	}
 }
@@ -105,7 +105,7 @@ function nprstory_api_delete ( $post_ID ) {
 		if ( empty( $retrieved ) || $retrieved == 0) {
 			$api->send_request( $api->create_NPRML( $post ), $post_ID);
 		} else {
-			nprstory_error_log('Pushing delete action to the NPR Story API for the story with post_ID ' . (str)  $post_ID );
+			nprstory_error_log('Pushing delete action to the NPR Story API for the story with post_ID ' . $post_ID );
 			$api->send_delete( $api_id );
 		}
 	}

--- a/push_story.php
+++ b/push_story.php
@@ -230,7 +230,6 @@ function nprstory_validation_callback_api_key( $value ) {
  */
 function nprstory_validation_callback_pull_url( $value ) {
 	// Is this a URL? It better be a URL.
-	error_log( var_export( strpos( $value, 'http' ) !== 0 ), true );
 	if ( strpos( $value, 'http' ) !== 0 ) {
 		add_settings_error(
 			'ds_npr_api_pull_url',
@@ -244,7 +243,6 @@ function nprstory_validation_callback_pull_url( $value ) {
 }
 function nprstory_validation_callback_push_url( $value ) {
 	// Is this a URL? It better be a URL.
-	error_log(var_export( strpos( $value, 'http' ) !== 0 ), true);
 	if ( strpos( $value, 'http' ) !== 0 ) {
 		add_settings_error(
 			'ds_npr_api_push_url',

--- a/settings.php
+++ b/settings.php
@@ -120,7 +120,7 @@ function nprstory_api_get_multi_settings_callback() {
 	if ( wp_next_scheduled( 'npr_ds_hourly_cron' ) ) {
 		wp_clear_scheduled_hook( 'npr_ds_hourly_cron' );
 	}
-	error_log('updating the cron event');
+	nprstory_error_log('NPR Story API plugin: updating the npr_ds_hourly_cron event timer');
 	wp_schedule_event( time(), 'ds_interval', 'npr_ds_hourly_cron');
 }
 

--- a/settings.php
+++ b/settings.php
@@ -120,7 +120,7 @@ function nprstory_api_get_multi_settings_callback() {
 	if ( wp_next_scheduled( 'npr_ds_hourly_cron' ) ) {
 		wp_clear_scheduled_hook( 'npr_ds_hourly_cron' );
 	}
-	nprstory_error_log('NPR Story API plugin: updating the npr_ds_hourly_cron event timer');
+	nprstory_error_log( 'NPR Story API plugin: updating the npr_ds_hourly_cron event timer' );
 	wp_schedule_event( time(), 'ds_interval', 'npr_ds_hourly_cron');
 }
 

--- a/settings_ui.php
+++ b/settings_ui.php
@@ -9,7 +9,6 @@
 function nprstory_api_options_page() {
 ?>
     <div>
-        <h2>NPR API settings</h2>
         <form action="options.php" method="post">
             <?php settings_fields( 'ds_npr_api' ); ?>
             <?php do_settings_sections( 'ds_npr_api' ); ?>

--- a/tests/test-settings_ui.php
+++ b/tests/test-settings_ui.php
@@ -3,20 +3,26 @@
 class Test_SettingsUi extends WP_UnitTestCase {
 
 	function test_ds_npr_api_options_age() {
-		# Basic test of output -- expect to see the title of the page in the output
-		$this->expectOutputRegex('/NPR API settings/');
+		# Basic test of output -- expect to see a form and an input and a submit
+		$this->expectOutputRegex('/form/');
+		$this->expectOutputRegex('/input/');
+		$this->expectOutputRegex('/submit/');
 		nprstory_api_options_page();
 	}
 
 	function test_nprstory_api_get_multi_options_page() {
-		# Basic test of output -- expect to see the title of the page in the output
-		$this->expectOutputRegex('/Create an NPR API query/');
+		# Basic test of output -- expect to see a form and an input and a submit
+		$this->expectOutputRegex('/form/');
+		$this->expectOutputRegex('/input/');
+		$this->expectOutputRegex('/submit/');
 		nprstory_api_get_multi_options_page();
 	}
 
 	function test_nprstory_add_field_mapping_page() {
 		# Basic test of output -- expect to see a form printed in the output
 		$this->expectOutputRegex('/<form action\="options\.php" method\="post">/');
+		$this->expectOutputRegex('/input/');
+		$this->expectOutputRegex('/submit/');
 		nprstory_add_field_mapping_page();
 	}
 


### PR DESCRIPTION
## Changes

- create new function `nprstory_error_log($input)` that will only run `error_log` on the `$input` if `WP_DEBUG` is True
- change many `error_log`s to use `nprstory_error_log`
- identify `error_log`s that should always fire, because these may be identifying errors in the production environment
- remove trailing `?>` at end of `classes/nprml.php` as it may cause an error on some servers, also to match WordPress style guide: https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#remove-trailing-spaces

## Why

An error reported by @mike-douglas 
> Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/nprapi-wordpress/push_story.php:233) in /var/www/html/wp-includes/pluggable.php on line 1171

Messages left as `error_log` are where unexpected errors may occur, which may not always be reproducible from development or testing environments. `error_log` messages are intended to be after-the-fact records of problems unexpectedly occurring.

Messages switched to `nprstory_error_log` are now only `error_log`ged when `WP_DEBUG` is true because they aren't records of unexpected errors. They're primarily messages that things are operating as expected, which wouldn't need to be recorded in a production environment.

`error_log` is for when things are unexpectedly broken. `nprstory_error_log` is for confirmation that things are working, and for scenarios where things might be expectedly broken.