### PR TITLE
Fixed bug related to $my_array 

### DIFF
--- a/classes/NPRAPI.php
+++ b/classes/NPRAPI.php
@@ -122,8 +122,7 @@ class NPRAPI {
             if (!empty($parsed->{$key})){
               //if it's not an array, make an array, add the existing element to it
               if (!is_array($parsed->{$key})){
-                $my_array[] = $parsed->{$key};
-                $parsed->{$key} = $my_array;
+                $parsed->{$key} = array( $parsed->{$key} );
               }
               // then add the new child. 
               $parsed->{$key}[] = $this->parse_simplexml_element($current);
@@ -186,8 +185,7 @@ class NPRAPI {
           if (!empty($NPRMLElement->$i)){
             //if it's not an array, make an array, add the existing element to it
             if (!is_array($NPRMLElement->$i)) {
-              $my_array[] = $NPRMLElement->$i;
-              $NPRMLElement->$i = $my_array;
+              $NPRMLElement->$i = array( $NPRMLElement->$i );
             }
             // then add the new child. 
             $NPRMLElement->{$i}[] = $this->parse_simplexml_element($child);


### PR DESCRIPTION
The code that collects up subelements of a story &mdash; specifically `->parent` and `->byline` but potentially others &mdash; had a bug that copies a parent NPRMLElement into a Byline array of NPRMLElements because it does not clear the temporary `$my_array`.  This logic was in two places.

There really was no need for a temp var so I just inlined the creation of the array and assigned back to the same var.