### PR TITLE
Added an 'npr_image_crop_url' hook.

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -312,7 +312,22 @@ class NPRAPIWordpress extends NPRAPI {
                             if ( empty( $image_url ) && ! empty( $image->src ) ) {
                                 $image_url = $image->src;
                             }
-                            nprstory_error_log( 'Got image from: ' . $image_url );
+
+	                        /**
+	                         * Filters the image crop url
+	                         *
+	                         * Allows a site to decide which crop it prefers to use for thumbnail/featured image.
+	                         * Especially useful if/when the crop is way too big.
+	                         *
+	                         * @since 1.7
+	                         *
+	                         * @param string $image_url URL of image crop to download
+	                         * @param NPRMLEntity $story Story object created during import
+	                         * @param int $post_id Post ID or NULL if no post ID.
+	                         */
+	                        $image_url = apply_filters( 'npr_image_crop_url', $image_url, $story, $post_id );
+
+	                        nprstory_error_log( 'Got image from: ' . $image_url );
                             // Download file to temp location
                             $tmp = download_url( $image_url );
 


### PR DESCRIPTION
We are running into a problem where [**an extra large image**](https://media.npr.org/assets/img/2017/02/03/gettyimages-158558293-c00d8b7f38357d6a88152c80490d5d82ebc75547.jpg)  _(`height="4727"` and `width="6306"`)_ is causing the Nginx server to just bail with an `502 Bad Gateway`  in `WP_Image_Editor_Imagick->thumbnail_image()` on the `$this->image->resizeImage( $dst_w, $dst_h, $filter, 1 )`  line when `$dst_w` and  `$dst_h` are large.  Not always, but sometimes.

So I've added an `'npr_image_crop_url'` hook to allow a site to catch extra large images and perform alternate processing on them (such as having them resized using rsz.io, like this: [**1200px wide image**](http://media.npr.org.rsz.io/assets/img/2017/02/03/gettyimages-158558293-c00d8b7f38357d6a88152c80490d5d82ebc75547.jpg?width=1200). 

I am review this pull request soon and also that you will request it, to allow Atlanta's WABE.org to continue using the "official" plugin.

